### PR TITLE
Fixed markdown syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-![tricycle logo]
-(https://github.com/StellarArmy/tricycle/blob/master/plots/tricycle.gif)
+![tricycle logo](https://github.com/StellarArmy/tricycle/blob/master/plots/tricycle.gif)
 
 3 Periods, 2 Stars, 1 Age
 


### PR DESCRIPTION
Removed a space, allowing the GIF animation to be properly displayed in the README file.